### PR TITLE
Add Claude Code headless backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,60 @@ The transcript-based modes and memory-based mode now share the same answer scaff
 
 That change makes the `full_context` baseline meaningfully fairer than raw transcript stuffing for the next benchmark rerun.
 
+## Claude Code Headless Backend
+
+The harness can also use Claude Code headless mode instead of a direct API backend.
+
+Why use it:
+
+- no separate API billing setup if your Claude Code team account already covers usage
+- works cleanly for local benchmark automation
+- lets you test Claude models before deciding whether to add API-based runs later
+
+Recommended model pairing:
+
+- generation model: `sonnet`
+- judge model: `opus`
+
+Typical command:
+
+```bash
+run-long-context-harness \
+  --backend claude_code \
+  --judge-backend claude_code \
+  --model sonnet \
+  --judge-model opus \
+  --dataset datasets/long_context_v2_300k.jsonl \
+  --output results \
+  --run-name claude_headless_smoke \
+  --sleep-between-requests 1.5 \
+  --resume \
+  --limit 3 \
+  --report
+```
+
+Optional Claude-specific flags:
+
+- `--claude-binary /path/to/claude`
+- `--claude-mcp-config /absolute/path/to/mcp.json`
+- `--claude-max-budget-usd 10`
+
+Setup checklist for Claude Code headless:
+
+1. Install Claude Code so the `claude` binary is on your `PATH`.
+2. Sign in with your Claude Code team account.
+3. Verify headless mode works:
+
+```bash
+claude -p "Reply with the word ready" --model sonnet --output-format json
+```
+
+Notes:
+
+- for benchmark fairness, the Claude Code backend runs in tool-free headless mode by default
+- that means Claude behaves as a model backend, not as an autonomous coding agent
+- you can still pass `--claude-mcp-config`, but with tools disabled it will not materially affect the benchmark run
+
 Each run gets its own folder, for example:
 
 ```text

--- a/src/agentic_memory_long_context_bench/llm.py
+++ b/src/agentic_memory_long_context_bench/llm.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import time
 from dataclasses import asdict, dataclass
 from typing import Any, Protocol
@@ -11,6 +12,11 @@ from .generator import _estimate_text_tokens
 
 class GenerativeModel(Protocol):
     def generate(self, *, prompt: str) -> "ModelResponse":
+        ...
+
+
+class JudgeModel(Protocol):
+    def judge(self, *, prompt: str) -> dict[str, Any]:
         ...
 
 
@@ -46,7 +52,7 @@ class GeminiModel:
         api_key = os.getenv("GEMINI_API_KEY")
         if not api_key:
             raise ValueError(
-                "GEMINI_API_KEY is required to run the online harness. "
+                "GEMINI_API_KEY is required to run the online Gemini harness. "
                 "Export it before invoking run-long-context-harness."
             )
         self._client = genai.Client(api_key=api_key)
@@ -79,7 +85,7 @@ class GeminiModel:
             input_tokens=int(input_tokens),
             output_tokens=int(output_tokens),
             latency_ms=round(latency_ms, 2),
-            raw={"model": self.model},
+            raw={"provider": "gemini", "model": self.model},
         )
 
 
@@ -92,6 +98,159 @@ class GeminiJudge:
         payload = _extract_json_object(response.text)
         payload["_response"] = response.to_dict()
         return payload
+
+
+class ClaudeCodeModel:
+    def __init__(
+        self,
+        *,
+        model: str,
+        claude_binary: str = "claude",
+        mcp_config: str | None = None,
+        max_budget_usd: float | None = None,
+        extra_args: list[str] | None = None,
+    ):
+        self.model = model
+        self.claude_binary = claude_binary
+        self.mcp_config = mcp_config
+        self.max_budget_usd = max_budget_usd
+        self.extra_args = extra_args or []
+        if not shutil_which(self.claude_binary):
+            raise ValueError(
+                f"Claude Code binary '{self.claude_binary}' was not found on PATH. "
+                "Install Claude Code first or pass --claude-binary."
+            )
+
+    def generate(self, *, prompt: str) -> ModelResponse:
+        command = [
+            self.claude_binary,
+            "-p",
+            prompt,
+            "--model",
+            self.model,
+            "--output-format",
+            "json",
+            "--permission-mode",
+            "default",
+            "--tools",
+            "",
+            "--disable-slash-commands",
+            "--strict-mcp-config",
+        ]
+        if self.mcp_config:
+            command.extend(["--mcp-config", self.mcp_config])
+        if self.max_budget_usd is not None:
+            command.extend(["--max-budget-usd", str(self.max_budget_usd)])
+        command.extend(self.extra_args)
+
+        started = time.perf_counter()
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        fallback_latency_ms = round((time.perf_counter() - started) * 1000, 2)
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"Claude Code headless run failed with exit code {completed.returncode}: "
+                f"{completed.stderr.strip() or completed.stdout.strip()}"
+            )
+
+        payload = _extract_json_object(completed.stdout)
+        result_text = (payload.get("result") or payload.get("text") or "").strip()
+        usage = payload.get("usage") or {}
+        input_tokens = usage.get("input_tokens") or payload.get("input_tokens") or _estimate_text_tokens(prompt)
+        output_tokens = usage.get("output_tokens") or payload.get("output_tokens") or _estimate_text_tokens(result_text)
+        latency_ms = payload.get("duration_ms") or fallback_latency_ms
+        raw = {
+            "provider": "claude_code",
+            "model": self.model,
+            "cli_payload": payload,
+        }
+        if "total_cost_usd" in payload:
+            raw["total_cost_usd"] = payload["total_cost_usd"]
+
+        return ModelResponse(
+            text=result_text,
+            input_tokens=int(input_tokens),
+            output_tokens=int(output_tokens),
+            latency_ms=round(float(latency_ms), 2),
+            raw=raw,
+        )
+
+
+class ClaudeCodeJudge:
+    def __init__(self, *, model: str, **kwargs: Any):
+        self._model = ClaudeCodeModel(model=model, **kwargs)
+
+    def judge(self, *, prompt: str) -> dict[str, Any]:
+        response = self._model.generate(prompt=prompt)
+        payload = _extract_json_object(response.text)
+        payload["_response"] = response.to_dict()
+        if "total_cost_usd" in response.raw:
+            payload["_response"]["raw"]["total_cost_usd"] = response.raw["total_cost_usd"]
+        return payload
+
+
+def create_model(
+    *,
+    backend: str,
+    model: str,
+    max_retries: int,
+    initial_backoff_seconds: float,
+    backoff_multiplier: float,
+    max_backoff_seconds: float,
+    claude_binary: str,
+    claude_mcp_config: str | None,
+    claude_max_budget_usd: float | None,
+) -> GenerativeModel:
+    if backend == "gemini":
+        return GeminiModel(
+            model=model,
+            max_retries=max_retries,
+            initial_backoff_seconds=initial_backoff_seconds,
+            backoff_multiplier=backoff_multiplier,
+            max_backoff_seconds=max_backoff_seconds,
+        )
+    if backend == "claude_code":
+        return ClaudeCodeModel(
+            model=model,
+            claude_binary=claude_binary,
+            mcp_config=claude_mcp_config,
+            max_budget_usd=claude_max_budget_usd,
+        )
+    raise ValueError(f"Unsupported backend '{backend}'")
+
+
+def create_judge(
+    *,
+    backend: str,
+    model: str,
+    max_retries: int,
+    initial_backoff_seconds: float,
+    backoff_multiplier: float,
+    max_backoff_seconds: float,
+    claude_binary: str,
+    claude_mcp_config: str | None,
+    claude_max_budget_usd: float | None,
+) -> JudgeModel:
+    if backend == "gemini":
+        return GeminiJudge(
+            model=model,
+            max_retries=max_retries,
+            initial_backoff_seconds=initial_backoff_seconds,
+            backoff_multiplier=backoff_multiplier,
+            max_backoff_seconds=max_backoff_seconds,
+        )
+    if backend == "claude_code":
+        return ClaudeCodeJudge(
+            model=model,
+            claude_binary=claude_binary,
+            mcp_config=claude_mcp_config,
+            max_budget_usd=claude_max_budget_usd,
+        )
+    raise ValueError(f"Unsupported backend '{backend}'")
 
 
 def _extract_json_object(text: str) -> dict[str, Any]:
@@ -134,3 +293,12 @@ def _is_retryable_exception(exc: Exception) -> bool:
         "500",
     ]
     return any(marker in text for marker in retry_markers)
+
+
+def shutil_which(binary: str) -> str | None:
+    try:
+        import shutil
+
+        return shutil.which(binary)
+    except Exception:
+        return None

--- a/src/agentic_memory_long_context_bench/runner.py
+++ b/src/agentic_memory_long_context_bench/runner.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from .dataset import load_dataset
 from .generator import _estimate_conversation_tokens, _estimate_text_tokens
-from .llm import GeminiJudge, GeminiModel
+from .llm import JudgeModel, create_judge, create_model
 from .memory_mode import build_memory_prompt
 from .pricing import estimate_cost_usd
 from .scoring import score_response
@@ -41,6 +41,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run long-context evaluation modes against a dataset.")
     parser.add_argument("--dataset", type=Path, required=True, help="JSONL dataset path.")
     parser.add_argument("--output", type=Path, default=Path("results/latest_results.jsonl"))
+    parser.add_argument("--backend", type=str, default="gemini", choices=["gemini", "claude_code"])
+    parser.add_argument("--judge-backend", type=str, default="", choices=["", "gemini", "claude_code"])
     parser.add_argument("--model", type=str, default="gemini-2.5-flash")
     parser.add_argument("--judge-model", type=str, default="gemini-2.5-flash-lite")
     parser.add_argument("--modes", type=str, default="short_context,full_context,memory_enabled")
@@ -54,6 +56,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--initial-backoff-seconds", type=float, default=2.0)
     parser.add_argument("--backoff-multiplier", type=float, default=2.0)
     parser.add_argument("--max-backoff-seconds", type=float, default=30.0)
+    parser.add_argument("--claude-binary", type=str, default="claude")
+    parser.add_argument("--claude-mcp-config", type=str, default="")
+    parser.add_argument("--claude-max-budget-usd", type=float, default=0.0)
     parser.add_argument("--skip-judge", action="store_true")
     parser.add_argument("--report", action="store_true")
     return parser.parse_args()
@@ -64,6 +69,8 @@ def main() -> None:
     run_harness(
         dataset_path=args.dataset,
         output_path=args.output,
+        backend=args.backend,
+        judge_backend=args.judge_backend or args.backend,
         model_name=args.model,
         judge_model_name=args.judge_model,
         modes=[mode.strip() for mode in args.modes.split(",") if mode.strip()],
@@ -77,6 +84,9 @@ def main() -> None:
         initial_backoff_seconds=args.initial_backoff_seconds,
         backoff_multiplier=args.backoff_multiplier,
         max_backoff_seconds=args.max_backoff_seconds,
+        claude_binary=args.claude_binary,
+        claude_mcp_config=args.claude_mcp_config or None,
+        claude_max_budget_usd=args.claude_max_budget_usd or None,
         use_judge=not args.skip_judge,
         print_report=args.report,
     )
@@ -86,6 +96,8 @@ def run_harness(
     *,
     dataset_path: Path,
     output_path: Path,
+    backend: str,
+    judge_backend: str,
     model_name: str,
     judge_model_name: str,
     modes: list[str],
@@ -99,6 +111,9 @@ def run_harness(
     initial_backoff_seconds: float,
     backoff_multiplier: float,
     max_backoff_seconds: float,
+    claude_binary: str,
+    claude_mcp_config: str | None,
+    claude_max_budget_usd: float | None,
     use_judge: bool,
     print_report: bool,
 ) -> list[HarnessResult]:
@@ -106,20 +121,28 @@ def run_harness(
     if limit > 0:
         examples = examples[:limit]
 
-    model = GeminiModel(
+    model = create_model(
+        backend=backend,
         model=model_name,
         max_retries=max_retries,
         initial_backoff_seconds=initial_backoff_seconds,
         backoff_multiplier=backoff_multiplier,
         max_backoff_seconds=max_backoff_seconds,
+        claude_binary=claude_binary,
+        claude_mcp_config=claude_mcp_config,
+        claude_max_budget_usd=claude_max_budget_usd,
     )
     judge = (
-        GeminiJudge(
+        create_judge(
+            backend=judge_backend,
             model=judge_model_name,
             max_retries=max_retries,
             initial_backoff_seconds=initial_backoff_seconds,
             backoff_multiplier=backoff_multiplier,
             max_backoff_seconds=max_backoff_seconds,
+            claude_binary=claude_binary,
+            claude_mcp_config=claude_mcp_config,
+            claude_max_budget_usd=claude_max_budget_usd,
         )
         if use_judge
         else None
@@ -156,18 +179,10 @@ def run_harness(
                     if judge is not None
                     else None
                 )
-                total_cost = estimate_cost_usd(
-                    model_name,
-                    input_tokens=response.input_tokens,
-                    output_tokens=response.output_tokens,
-                )
+                total_cost = _response_cost_usd(model_name, response)
                 if judge_score is not None and "_response" in judge_score:
                     judge_response = judge_score["_response"]
-                    total_cost += estimate_cost_usd(
-                        judge_model_name,
-                        input_tokens=judge_response["input_tokens"],
-                        output_tokens=judge_response["output_tokens"],
-                    )
+                    total_cost += _judge_response_cost_usd(judge_model_name, judge_response)
 
                 result = HarnessResult(
                     example_id=example.id,
@@ -335,7 +350,7 @@ def _trim_turns_to_budget(turns: list[Turn], budget: int) -> list[Turn]:
     return list(reversed(selected))
 
 
-def _judge_example(*, example: BenchmarkExample, answer: str, judge: GeminiJudge | None) -> dict[str, Any]:
+def _judge_example(*, example: BenchmarkExample, answer: str, judge: JudgeModel | None) -> dict[str, Any]:
     if judge is None:
         return {}
     prompt = (
@@ -348,6 +363,28 @@ def _judge_example(*, example: BenchmarkExample, answer: str, judge: GeminiJudge
         f"MODEL_ANSWER:\n{answer}\n"
     )
     return judge.judge(prompt=prompt)
+
+
+def _response_cost_usd(model_name: str, response: Any) -> float:
+    raw = getattr(response, "raw", {}) or {}
+    if "total_cost_usd" in raw:
+        return round(float(raw["total_cost_usd"]), 6)
+    return estimate_cost_usd(
+        model_name,
+        input_tokens=response.input_tokens,
+        output_tokens=response.output_tokens,
+    )
+
+
+def _judge_response_cost_usd(model_name: str, judge_response: dict[str, Any]) -> float:
+    raw = judge_response.get("raw") or {}
+    if "total_cost_usd" in raw:
+        return round(float(raw["total_cost_usd"]), 6)
+    return estimate_cost_usd(
+        model_name,
+        input_tokens=judge_response["input_tokens"],
+        output_tokens=judge_response["output_tokens"],
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,53 @@
+import subprocess
+
+from agentic_memory_long_context_bench.llm import ClaudeCodeModel, create_model
+
+
+def test_create_model_supports_claude_code(monkeypatch):
+    monkeypatch.setattr("agentic_memory_long_context_bench.llm.shutil_which", lambda _: "/usr/bin/claude")
+    model = create_model(
+        backend="claude_code",
+        model="sonnet",
+        max_retries=5,
+        initial_backoff_seconds=2.0,
+        backoff_multiplier=2.0,
+        max_backoff_seconds=30.0,
+        claude_binary="claude",
+        claude_mcp_config=None,
+        claude_max_budget_usd=None,
+    )
+    assert isinstance(model, ClaudeCodeModel)
+
+
+def test_claude_code_model_parses_headless_json(monkeypatch):
+    captured = {}
+
+    def fake_run(command, capture_output, text, check):
+        captured["command"] = command
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout='{"type":"result","subtype":"success","total_cost_usd":0.0123,"duration_ms":1234,"result":"hello world","usage":{"input_tokens":111,"output_tokens":22}}',
+            stderr="",
+        )
+
+    monkeypatch.setattr("agentic_memory_long_context_bench.llm.shutil_which", lambda _: "/usr/bin/claude")
+    monkeypatch.setattr("agentic_memory_long_context_bench.llm.subprocess.run", fake_run)
+
+    model = ClaudeCodeModel(
+        model="sonnet",
+        claude_binary="claude",
+        mcp_config="/tmp/test-mcp.json",
+        max_budget_usd=1.5,
+    )
+    response = model.generate(prompt="test prompt")
+
+    assert response.text == "hello world"
+    assert response.input_tokens == 111
+    assert response.output_tokens == 22
+    assert response.latency_ms == 1234.0
+    assert response.raw["provider"] == "claude_code"
+    assert response.raw["total_cost_usd"] == 0.0123
+    assert "--model" in captured["command"]
+    assert "--mcp-config" in captured["command"]
+    assert "--tools" in captured["command"]


### PR DESCRIPTION
harness for headless backend for sonnet + opus 
This pull request adds support for running the long-context benchmark harness with Claude Code in headless mode as an alternative backend to Gemini, including both model generation and judging. It introduces new command-line arguments for configuring Claude Code, implements the backend selection logic, and provides tests for the new functionality. The documentation is updated to explain how to use Claude Code mode.

**Claude Code backend support:**

* Added `ClaudeCodeModel` and `ClaudeCodeJudge` classes to `llm.py` to run prompts and judge responses using the Claude Code CLI in headless mode, including robust command invocation, output parsing, and error handling.
* Implemented `create_model` and `create_judge` factory functions for dynamic backend selection between Gemini and Claude Code, and refactored runner logic to use these abstractions. [[1]](diffhunk://#diff-e66caef9539237927923c52104568ea82a14ea9cbcb5c4c11518f857a94c87f4R103-R255) [[2]](diffhunk://#diff-8af5786d292659cbbc4b4c3dd431c90cdcf260ba77f77156c1f87c8a2698a9faR114-R145)
* Added new command-line arguments (`--backend`, `--judge-backend`, `--claude-binary`, `--claude-mcp-config`, `--claude-max-budget-usd`) to `runner.py` to enable and configure Claude Code runs. [[1]](diffhunk://#diff-8af5786d292659cbbc4b4c3dd431c90cdcf260ba77f77156c1f87c8a2698a9faR44-R45) [[2]](diffhunk://#diff-8af5786d292659cbbc4b4c3dd431c90cdcf260ba77f77156c1f87c8a2698a9faR59-R61)

**Cost estimation and result handling:**

* Updated cost estimation logic to support Claude Code’s explicit cost reporting (`total_cost_usd`), falling back to token-based estimation if not present. [[1]](diffhunk://#diff-8af5786d292659cbbc4b4c3dd431c90cdcf260ba77f77156c1f87c8a2698a9faL159-R185) [[2]](diffhunk://#diff-8af5786d292659cbbc4b4c3dd431c90cdcf260ba77f77156c1f87c8a2698a9faR368-R389)

**Documentation and testing:**

* Added a comprehensive section to `README.md` explaining how to use the Claude Code headless backend, including setup steps and example commands.
* Added unit tests for Claude Code backend creation and output parsing in `test_llm.py`. 